### PR TITLE
Adjust anytime container spacing

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFoundScreen() {
     <>
       <Stack.Screen options={{ title: 'Oops!' }} />
       <View style={styles.container}>
-        <Text style={styles.text}>This screen doesn't exist.</Text>
+        <Text style={styles.text}>This screen doesn&apos;t exist.</Text>
         <Link href="/" style={styles.link}>
           <Text>Go to home screen!</Text>
         </Link>

--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -373,7 +373,7 @@ const styles = StyleSheet.create({
     compactInputValue: { fontSize: 14, fontWeight: '500' },
     disabledButton: { backgroundColor: '#f3f4f6' },
     disabledText: { color: '#9ca3af' },
-    anytimeContainer: { flexDirection: 'row', alignItems: 'center', marginLeft: 'auto' },
+    anytimeContainer: { flexDirection: 'row', alignItems: 'center', marginLeft: 8 },
     checkbox: { width: 18, height: 18, borderWidth: 1, borderColor: '#d1d5db', borderRadius: 3, marginRight: 6, justifyContent: 'center', alignItems: 'center' },
     checkedBox: { backgroundColor: '#0078d4', borderColor: '#0078d4' },
     checkmark: { color: 'white', fontSize: 12, fontWeight: 'bold' },


### PR DESCRIPTION
## Summary
- place the "Anytime" checkbox right beside the "Complete by" button by using a small fixed margin
- escape apostrophe on not-found screen to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689f5a6a0168832492f230d07edd1050