### PR TITLE
Position time picker relative to input

### DIFF
--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -47,6 +47,7 @@ const CustomDayComponent = ({ date, state, marking, onPress }) => {
 // --- MAIN FORM COMPONENT ---
 const TaskEventForm: React.FC<TaskEventFormProps> = ({ mode, initialData, onSubmitSuccess, onClose }) => {
   const dateInputRef = useRef<TouchableOpacity>(null);
+  const timeInputRef = useRef<TouchableOpacity>(null);
 
   // Helper function to get default time (current time + 1 hour, rounded to nearest 15 min)
   const getDefaultTime = () => {
@@ -269,9 +270,15 @@ const TaskEventForm: React.FC<TaskEventFormProps> = ({ mode, initialData, onSubm
                       </View>
                       
                       <View>
-                        <TouchableOpacity 
+                        <TouchableOpacity
+                          ref={timeInputRef}
                           style={[styles.compactTimeButton, formData.isAnytime && styles.disabledButton]}
-                          onPress={() => setShowTimePicker(!showTimePicker)}
+                          onPress={() => {
+                            timeInputRef.current?.measure((_, __, w, h, px, py) => {
+                              setTimePickerPosition({ x: px, y: py, width: w, height: h });
+                              setShowTimePicker(!showTimePicker);
+                            });
+                          }}
                           disabled={formData.isAnytime}
                         >
                           <Text style={[styles.compactInputLabel, formData.isAnytime && styles.disabledText]}>Complete by</Text>
@@ -325,7 +332,7 @@ const TaskEventForm: React.FC<TaskEventFormProps> = ({ mode, initialData, onSubm
         {/* Pop-up Time Picker Modal */}
         <Modal transparent visible={showTimePicker} onRequestClose={() => setShowTimePicker(false)}>
             <TouchableOpacity style={StyleSheet.absoluteFill} onPress={() => setShowTimePicker(false)}>
-                <View style={styles.timePickerPopup}>
+                <View style={[styles.timePickerPopup, { top: timePickerPosition.y, left: timePickerPosition.x + timePickerPosition.width + 8 }]}> 
                     <FlatList
                         data={timeOptions}
                         keyExtractor={(item) => item}
@@ -394,8 +401,8 @@ const styles = StyleSheet.create({
     },
     timePickerPopup: {
         position: 'absolute',
-        width: 140, // Made narrower
-        maxHeight: 200,
+        width: 100, // Made narrower
+        maxHeight: 160,
         backgroundColor: '#ffffff',
         borderRadius: 8,
         borderWidth: 1,


### PR DESCRIPTION
## Summary
- measure time input to position picker popup
- attach ref to "Complete by" button
- shrink time picker popup width

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_b_689f5d4effd88324807d26928b29a42e