### PR TITLE
Shrink mini calendar and shorten weekday labels

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Drawer } from 'expo-router/drawer';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { SideMenu } from '@/components/SideMenu';
+import '@/lib/calendarLocale';
 
 export default function RootLayout() {
   useFrameworkReady();

--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -318,8 +318,8 @@ const TaskEventForm: React.FC<TaskEventFormProps> = ({ mode, initialData, onSubm
         {/* Pop-up Mini Calendar Modal */}
         <Modal transparent visible={showMiniCalendar} onRequestClose={() => setShowMiniCalendar(false)}>
           <TouchableOpacity style={StyleSheet.absoluteFill} onPress={() => setShowMiniCalendar(false)}>
-            <View style={[styles.calendarPopup, { top: datePickerPosition.y + datePickerPosition.height, left: datePickerPosition.x }]}>
-              <ScrollView style={{ maxHeight: 240 }} nestedScrollEnabled>
+            <View style={[styles.calendarPopup, { top: datePickerPosition.y + datePickerPosition.height, left: datePickerPosition.x }]}> 
+              <ScrollView style={{ maxHeight: 200 }} nestedScrollEnabled>
                 <Calendar
                   onDayPress={onCalendarDayPress}
                   markedDates={{ [formData.dueDate.toISOString().split('T')[0]]: { selected: true } }}
@@ -389,8 +389,8 @@ const styles = StyleSheet.create({
     anytimeLabel: { fontSize: 14 },
     calendarPopup: {
         position: 'absolute',
-        width: 240,
-        maxHeight: 280,
+        width: 200,
+        maxHeight: 220,
         backgroundColor: '#ffffff',
         borderRadius: 8,
         borderWidth: 1,
@@ -419,9 +419,9 @@ const styles = StyleSheet.create({
     },
     timeOptionPopup: { padding: 12, borderBottomWidth: 1, borderBottomColor: '#f3f4f6' },
     timeOptionTextPopup: { textAlign: 'center' },
-    dayContainer: { width: 24, height: 16, justifyContent: 'center', alignItems: 'center' },
-    dayText: { fontSize: 10 },
-    selectedDay: { backgroundColor: '#0078d4', borderRadius: 14, width: 28, height: 28 },
+    dayContainer: { width: 20, height: 20, justifyContent: 'center', alignItems: 'center' },
+    dayText: { fontSize: 8 },
+    selectedDay: { backgroundColor: '#0078d4', borderRadius: 10, width: 20, height: 20 },
     selectedDayText: { color: 'white' },
     todayText: { color: '#0078d4', fontWeight: 'bold' },
     disabledDayText: { color: '#d9e1e8' },

--- a/lib/calendarLocale.ts
+++ b/lib/calendarLocale.ts
@@ -1,0 +1,8 @@
+import { LocaleConfig } from 'react-native-calendars';
+
+LocaleConfig.locales['en-short'] = {
+  ...LocaleConfig.locales['en'],
+  dayNamesShort: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+};
+
+LocaleConfig.defaultLocale = 'en-short';


### PR DESCRIPTION
## Summary
- Shrink mini calendar popup and selected-day circle
- Use single-letter weekday headers across calendars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_b_689f62a38c5883249ceddafadc8847dd