### PR TITLE
Add start and end time support for events

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -11,6 +11,8 @@ interface Task {
   id: string;
   title: string;
   due_date?: string;
+  start_time?: string;
+  end_time?: string;
   is_urgent?: boolean;
   is_important?: boolean;
   status?: string;


### PR DESCRIPTION
## Summary
- Capture start and end times for scheduled events in TaskEventForm and convert them to ISO strings
- Include event start_time and end_time in Supabase insert payload when appropriate
- Extend Task interface to expose optional start_time and end_time fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689fadb26bcc8324b1fac920b5131557