### PR TITLE
fix: remove incompatible expo-auth-session plugin

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,15 +17,9 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router", 
-      "expo-font", 
-      "expo-web-browser",
-      [
-        "expo-auth-session",
-        {
-          "schemes": ["myapp"]
-        }
-      ]
+      "expo-router",
+      "expo-font",
+      "expo-web-browser"
     ],
     "experiments": {
       "typedRoutes": true


### PR DESCRIPTION
## Summary
- remove `expo-auth-session` plugin from app configuration to prevent dev server crash

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: installs eslint but did not complete)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_689fe7326bb48324b67b4492433268c8