### PR TITLE
Fix task editing by updating tasks table reference

### DIFF
--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -252,7 +252,7 @@ const toDateString = (date: Date) => {
         if (mode === 'edit' && initialData?.id) {
             // Update existing task
             const { data, error } = await supabase
-                .from('0007-ap-tasks')
+                .from('0008-ap-tasks')
                 .update(payload)
                 .eq('id', initialData.id)
                 .select()
@@ -262,7 +262,7 @@ const toDateString = (date: Date) => {
         } else {
             // Create new task
             const { data, error } = await supabase
-                .from('0007-ap-tasks')
+                .from('0008-ap-tasks')
                 .insert(payload)
                 .select()
                 .single();


### PR DESCRIPTION
## Summary
- fix task editing by pointing task updates/inserts to the new `0008-ap-tasks` table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_b_68a226860ec483248d25086f4c347fa4