### PR TITLE
feat: update roles tables to v0008

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -234,9 +234,9 @@ export default function Dashboard() {
         { data: notesData },
         { data: delegatesData }
       ] = await Promise.all([
-        supabase.from('0008-ap-universal-roles-join').select('parent_id, role:0007-ap-roles(id, label)').in('parent_id', taskIds),
-        supabase.from('0008-ap-universal-domains-join').select('parent_id, domain:0007-ap-domains(id, name)').in('parent_id', taskIds),
-        supabase.from('0008-ap-universal-goals-join').select('parent_id, goal:0007-ap-goals-12wk(id, title)').in('parent_id', taskIds),
+        supabase.from('0008-ap-universal-roles-join').select('parent_id, role:0008-ap-roles(id, label)').in('parent_id', taskIds),
+        supabase.from('0008-ap-universal-domains-join').select('parent_id, domain:0008-ap-domains(id, name)').in('parent_id', taskIds),
+        supabase.from('0008-ap-universal-goals-join').select('parent_id, goal:0008-ap-goals-12wk(id, title)').in('parent_id', taskIds),
         supabase.from('0008-ap-universal-notes-join').select('parent_id, note_id').in('parent_id', taskIds),
         supabase.from('0008-ap-universal-delegates-join').select('parent_id, delegate_id').in('parent_id', taskIds),
       ]);

--- a/app/(tabs)/roles.tsx
+++ b/app/(tabs)/roles.tsx
@@ -30,7 +30,7 @@ export default function Roles() {
 
     // Fetch only the roles for the current user that are marked as active
     const { data, error } = await supabase
-      .from('0007-ap-roles')
+      .from('0008-ap-roles')
       .select('*')
       .eq('user_id', user.id)
       .eq('is_active', true);

--- a/components/settings/ManageRolesModal.tsx
+++ b/components/settings/ManageRolesModal.tsx
@@ -63,8 +63,8 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
       return;
     }
 
-    const { data: presetData, error: presetError } = await supabase.from('0007-ap-preset-roles').select('id, label, category');
-    const { data: userData, error: userError } = await supabase.from('0007-ap-roles').select('*').eq('user_id', user.id);
+    const { data: presetData, error: presetError } = await supabase.from('0008-ap-preset-roles').select('id, label, category');
+    const { data: userData, error: userError } = await supabase.from('0008-ap-roles').select('*').eq('user_id', user.id);
 
     if (presetError || userError) {
       Alert.alert('Error fetching data', presetError?.message || userError?.message);
@@ -81,7 +81,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
     if (!user) return;
 
     const { data, error } = await supabase
-      .from('0007-ap-roles')
+      .from('0008-ap-roles')
       .insert({ 
         label: customRoleLabel.trim(), 
         user_id: user.id, 
@@ -115,7 +115,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
       
       // Update database in background without awaiting
       supabase
-        .from('0007-ap-roles')
+        .from('0008-ap-roles')
         .update({ 
           is_active: !existingUserRole.is_active,
           updated_at: new Date().toISOString()
@@ -148,7 +148,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
       
       // Insert into database in background
       supabase
-        .from('0007-ap-roles')
+        .from('0008-ap-roles')
         .insert({
           label: presetRole.label, 
           user_id: user.id, 
@@ -255,7 +255,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
                                 // This can also be made optimistic
                                 const updatedRoles = userRoles.map(r => r.id === role.id ? { ...r, is_active: !r.is_active } : r);
                                 setUserRoles(updatedRoles);
-                                await supabase.from('0007-ap-roles').update({ 
+                                await supabase.from('0008-ap-roles').update({
                                   is_active: !role.is_active,
                                   updated_at: new Date().toISOString()
                                 }).eq('id', role.id);


### PR DESCRIPTION
## Summary
- switch settings role management to use 0008 tables
- update roles screen and dashboard joins for 0008 data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (warn: ESLint installation required, no config)

------
https://chatgpt.com/codex/tasks/task_b_68a23de4de84832480a417f08c1d582f