### PR TITLE
fix: use profile_id for role queries

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -207,7 +207,7 @@ export default function Dashboard() {
       let taskQuery = supabase
         .from('0008-ap-tasks')
         .select('*')
-        .eq('user_id', user.id)
+        .eq('profile_id', user.id)
         .neq('status', 'completed')
         .neq('status', 'cancelled');
 

--- a/app/(tabs)/roles.tsx
+++ b/app/(tabs)/roles.tsx
@@ -32,7 +32,7 @@ export default function Roles() {
     const { data, error } = await supabase
       .from('0008-ap-roles')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('profile_id', user.id)
       .eq('is_active', true);
 
     if (error) {

--- a/components/settings/ManageRolesModal.tsx
+++ b/components/settings/ManageRolesModal.tsx
@@ -28,7 +28,7 @@ interface UserRole {
   id: string;
   label: string;
   is_active: boolean;
-  user_id: string;
+  profile_id: string;
   preset_role_id?: string;
 }
 
@@ -64,7 +64,10 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
     }
 
     const { data: presetData, error: presetError } = await supabase.from('0008-ap-preset-roles').select('id, label, category');
-    const { data: userData, error: userError } = await supabase.from('0008-ap-roles').select('*').eq('user_id', user.id);
+    const { data: userData, error: userError } = await supabase
+      .from('0008-ap-roles')
+      .select('*')
+      .eq('profile_id', user.id);
 
     if (presetError || userError) {
       Alert.alert('Error fetching data', presetError?.message || userError?.message);
@@ -84,7 +87,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
       .from('0008-ap-roles')
       .insert({ 
         label: customRoleLabel.trim(), 
-        user_id: user.id, 
+        profile_id: user.id,
         is_active: true,
         category: 'Other',
         created_at: new Date().toISOString()
@@ -138,7 +141,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
       const optimisticRole = { 
         id: tempId,
         label: presetRole.label, 
-        user_id: user.id, 
+        profile_id: user.id,
         preset_role_id: presetRole.id, 
         is_active: true 
       };
@@ -151,7 +154,7 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
         .from('0008-ap-roles')
         .insert({
           label: presetRole.label, 
-          user_id: user.id, 
+        profile_id: user.id,
           preset_role_id: presetRole.id, 
           is_active: true,
           category: presetRole.category,

--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -137,10 +137,10 @@ const toDateString = (date: Date) => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      const { data: roleData } = await supabase.from("0008-ap-roles").select("id,label").eq("user_id", user.id).eq("is_active", true);
+        const { data: roleData } = await supabase.from("0008-ap-roles").select("id,label").eq("profile_id", user.id).eq("is_active", true);
       const { data: domainData } = await supabase.from("0008-ap-domains").select("id,name");
-      const { data: krData } = await supabase.from("0008-ap-key-relationships").select("id,name,role_id").eq("user_id", user.id);
-      const { data: goalData } = await supabase.from("0008-ap-goals-12wk").select("id,title").eq("user_id", user.id).eq("status", "active");
+        const { data: krData } = await supabase.from("0008-ap-key-relationships").select("id,name,role_id").eq("profile_id", user.id);
+        const { data: goalData } = await supabase.from("0008-ap-goals-12wk").select("id,title").eq("profile_id", user.id).eq("status", "active");
       
       setRoles(roleData || []);
       setDomains(domainData || []);
@@ -226,7 +226,7 @@ const toDateString = (date: Date) => {
         if (!user) throw new Error("User not found");
 
         const payload: any = {
-            user_id: user.id,
+            profile_id: user.id,
             title: formData.title,
             is_urgent: formData.is_urgent,
             is_important: formData.is_important,
@@ -286,15 +286,15 @@ const taskId = taskData.id;
         }
 
         // Generate join rows for each relationship
-        const roleJoins = formData.selectedRoleIds.map(role_id => ({ parent_id: taskId, parent_type: 'task', role_id, user_id: user.id }));
-        const domainJoins = formData.selectedDomainIds.map(domain_id => ({ parent_id: taskId, parent_type: 'task', domain_id, user_id: user.id }));
-        const krJoins = formData.selectedKeyRelationshipIds.map(key_relationship_id => ({ parent_id: taskId, parent_type: 'task', key_relationship_id, user_id: user.id }));
+        const roleJoins = formData.selectedRoleIds.map(role_id => ({ parent_id: taskId, parent_type: 'task', role_id, profile_id: user.id }));
+        const domainJoins = formData.selectedDomainIds.map(domain_id => ({ parent_id: taskId, parent_type: 'task', domain_id, profile_id: user.id }));
+        const krJoins = formData.selectedKeyRelationshipIds.map(key_relationship_id => ({ parent_id: taskId, parent_type: 'task', key_relationship_id, profile_id: user.id }));
 
         // Handle notes
         if (formData.notes) {
-            const { data: noteData, error: noteError } = await supabase.from('0008-ap-notes').insert({ user_id: user.id, content: formData.notes }).select().single();
+            const { data: noteData, error: noteError } = await supabase.from('0008-ap-notes').insert({ profile_id: user.id, content: formData.notes }).select().single();
             if (noteError) throw noteError;
-            await supabase.from('0008-ap-universal-notes-join').insert({ parent_id: taskId, parent_type: 'task', note_id: noteData.id, user_id: user.id });
+            await supabase.from('0008-ap-universal-notes-join').insert({ parent_id: taskId, parent_type: 'task', note_id: noteData.id, profile_id: user.id });
         }
 
         // Insert into universal join tables


### PR DESCRIPTION
## Summary
- use `profile_id` instead of `user_id` when fetching active roles
- align ManageRolesModal and task form role logic with `profile_id`
- fetch tasks by `profile_id`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo lint attempted to install eslint and did not finish)*

------
https://chatgpt.com/codex/tasks/task_b_68a24194c1c48324bc784a8e80c25a8f