### PR TITLE
fix: align domain joins with existing table

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -235,7 +235,7 @@ export default function Dashboard() {
         { data: delegatesData }
       ] = await Promise.all([
         supabase.from('0008-ap-universal-roles-join').select('parent_id, role:0008-ap-roles(id, label)').in('parent_id', taskIds),
-        supabase.from('0008-ap-universal-domains-join').select('parent_id, domain:0008-ap-domains(id, name)').in('parent_id', taskIds),
+        supabase.from('0008-ap-universal-domains-join').select('parent_id, domain:0007-ap-domains(id, name)').in('parent_id', taskIds),
         supabase.from('0008-ap-universal-goals-join').select('parent_id, goal:0008-ap-goals-12wk(id, title)').in('parent_id', taskIds),
         supabase.from('0008-ap-universal-notes-join').select('parent_id, note_id').in('parent_id', taskIds),
         supabase.from('0008-ap-universal-delegates-join').select('parent_id, delegate_id').in('parent_id', taskIds),

--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -138,7 +138,7 @@ const toDateString = (date: Date) => {
       if (!user) return;
 
         const { data: roleData } = await supabase.from("0008-ap-roles").select("id,label").eq("profile_id", user.id).eq("is_active", true);
-      const { data: domainData } = await supabase.from("0008-ap-domains").select("id,name");
+      const { data: domainData } = await supabase.from("0007-ap-domains").select("id,name");
         const { data: krData } = await supabase.from("0008-ap-key-relationships").select("id,name,role_id").eq("profile_id", user.id);
         const { data: goalData } = await supabase.from("0008-ap-goals-12wk").select("id,title").eq("profile_id", user.id).eq("status", "active");
       


### PR DESCRIPTION
## Summary
- switch domain lookup in TaskEventForm to use `0007-ap-domains`
- query `0008-ap-universal-domains-join` against `0007-ap-domains` in dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a2442a55648324834e4df0103e93db