### PR TITLE
Add profile_id to tasks table with RLS policies

### DIFF
--- a/supabase/migrations/20250101000000_add_profile_id_to_0008_ap_tasks.sql
+++ b/supabase/migrations/20250101000000_add_profile_id_to_0008_ap_tasks.sql
@@ -1,0 +1,19 @@
+-- Add profile_id column referencing profiles
+ALTER TABLE "0008-ap-tasks"
+  ADD COLUMN profile_id uuid NOT NULL REFERENCES profiles(id);
+
+-- Index to speed up profile lookups
+CREATE INDEX IF NOT EXISTS idx_0008_ap_tasks_profile_id ON "0008-ap-tasks"(profile_id);
+
+-- Enable row level security
+ALTER TABLE "0008-ap-tasks" ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to select their own tasks
+CREATE POLICY "Select own tasks" ON "0008-ap-tasks"
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+-- Allow users to insert tasks for themselves
+CREATE POLICY "Insert own tasks" ON "0008-ap-tasks"
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);


### PR DESCRIPTION
## Summary
- add migration for adding `profile_id` column to `0008-ap-tasks` table
- index `profile_id` and enable row-level security with select/insert policies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(installs eslint and exits)*

------
https://chatgpt.com/codex/tasks/task_b_68a246a686fc8324b409d8aae5acc5e9