### PR TITLE
Simplify role modal data fetching

### DIFF
--- a/components/settings/ManageRolesModal.tsx
+++ b/components/settings/ManageRolesModal.tsx
@@ -48,11 +48,9 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
 
   useEffect(() => {
     if (visible) {
-      fetchData().then(() => {
-        setCollapsedCategories(Object.keys(groupedPresetRoles));
-      });
+      fetchData();
     }
-  }, [visible, presetRoles.length]);
+  }, [visible]);
 
   const fetchData = async () => {
     setLoading(true);
@@ -72,7 +70,9 @@ export function ManageRolesModal({ visible, onClose }: ManageRolesModalProps) {
     if (presetError || userError) {
       Alert.alert('Error fetching data', presetError?.message || userError?.message);
     } else {
+      const categories = Array.from(new Set((presetData || []).map(r => r.category)));
       setPresetRoles(presetData || []);
+      setCollapsedCategories(categories);
       setUserRoles(userData || []);
     }
     setLoading(false);


### PR DESCRIPTION
## Summary
- fetch preset roles once per modal open
- derive collapsed categories from fetched roles
- remove preset role length dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a24d65eacc83248cb7f18be2dcdb79