### PR TITLE
Add start script for Expo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
+    "start": "expo start",
     "build:web": "expo export --platform web",
     "lint": "expo lint"
   },


### PR DESCRIPTION
## Summary
- add `start` script to run the Expo development server

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint -- --no-interactive` (fails: Unexpected --no-interactive)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_68a48ecf91c48324bcd5115ff0051556