### PR TITLE
feat: add supabase client helper

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,23 @@
 import { Redirect } from 'expo-router';
-import { supabase } from '@/lib/supabase';
+import { getSupabaseClient } from '@/lib/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
 export default function Index() {
+  let supabase: SupabaseClient;
+  try {
+    supabase = getSupabaseClient();
+  } catch (error) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={styles.loadingText}>
+          {error instanceof Error ? error.message : 'Supabase client not available.'}
+        </Text>
+      </View>
+    );
+  }
+
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -29,7 +43,7 @@ export default function Index() {
     });
 
     return () => subscription?.unsubscribe();
-  }, []);
+  }, [supabase]);
 
   if (loading) {
     return (

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -2,9 +2,25 @@ import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { supabase } from '@/lib/supabase';
+import { getSupabaseClient } from '@/lib/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 export default function LoginScreen() {
+  let supabase: SupabaseClient;
+  try {
+    supabase = getSupabaseClient();
+  } catch (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.centered}>
+          <Text style={styles.errorText}>
+            {error instanceof Error ? error.message : 'Supabase client not available.'}
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -223,5 +239,16 @@ const styles = StyleSheet.create({
     color: '#0078d4',
     fontSize: 14,
     fontWeight: '500',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#ef4444',
+    textAlign: 'center',
+    padding: 16,
   },
 });

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -19,3 +19,12 @@ export const supabase = supabaseUrl && supabaseAnonKey ? createClient(supabaseUr
     detectSessionInUrl: false,
   },
 }) : null;
+
+export function getSupabaseClient() {
+  if (!supabase) {
+    throw new Error(
+      'Supabase client is not initialized. Check EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+  return supabase;
+}


### PR DESCRIPTION
## Summary
- add `getSupabaseClient` helper and fallback rendering when not configured
- use helper in index and login screens to surface clearer error state

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 19 errors, 40 warnings)


------
https://chatgpt.com/codex/tasks/task_b_68a4928947a48324a9ede181817a3c2b