### PR TITLE
Use helper for Supabase client and add error guards

### DIFF
--- a/components/SideMenu.tsx
+++ b/components/SideMenu.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Alert } from 'rea
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Calendar, MessageCircle, Settings, LogOut } from 'lucide-react-native';
-import { supabase } from '@/lib/supabase'; // <-- Import Supabase
+import { getSupabaseClient } from '@/lib/supabase';
 
 const menuItems = [
   { id: 'calendar', title: 'Calendar View', icon: Calendar, route: '/calendar' },
@@ -20,12 +20,18 @@ export function SideMenu() {
 
   // --- ADD THIS FUNCTION ---
   const handleSignOut = async () => {
-    const { error } = await supabase.auth.signOut();
-    if (error) {
-      Alert.alert('Error signing out', error.message);
-    } else {
-      // This will clear the local session and send the user to the login screen
-      router.replace('/login'); 
+    try {
+      const supabase = getSupabaseClient();
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        Alert.alert('Error signing out', error.message);
+      } else {
+        // This will clear the local session and send the user to the login screen
+        router.replace('/login');
+      }
+    } catch (error) {
+      console.error('Error signing out:', error);
+      Alert.alert('Error', (error as Error).message);
     }
   };
   // -------------------------


### PR DESCRIPTION
## Summary
- replace direct Supabase imports with getSupabaseClient helper
- wrap Supabase usage in try/catch with user-friendly alerts

## Testing
- `npm run lint` *(fails: No ESLint config found. Configuring automatically...)*

------
https://chatgpt.com/codex/tasks/task_b_68a4b144f7ec8324a66d8f31f8b6b756