### PR TITLE
fix: ensure imports precede executable code in layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,4 @@
 
-console.log("ENTRY: file loaded");
 import 'react-native-gesture-handler';
 import 'react-native-reanimated';
 import { useEffect } from 'react';
@@ -8,6 +7,8 @@ import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { SideMenu } from '@/components/SideMenu';
 import '@/lib/calendarLocale';
+
+console.log('ENTRY: file loaded');
 
 export default function RootLayout() {
   useFrameworkReady();


### PR DESCRIPTION
## Summary
- move entry log after imports in app/_layout

## Testing
- `npm run lint` *(fails: React Hooks called conditionally in existing code)*
- `npx expo start -c`

------
https://chatgpt.com/codex/tasks/task_b_68a4b81cec24832488961c9b5ee8f801