### PR TITLE
chore: remove unused useEffect import

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,6 @@
 
 import 'react-native-gesture-handler';
 import 'react-native-reanimated';
-import { useEffect } from 'react';
 import { Drawer } from 'expo-router/drawer';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';


### PR DESCRIPTION
## Summary
- remove unused `useEffect` import from root layout

## Testing
- `npx tsc --noEmit` *(fails: Binding element 'visible' implicitly has an 'any' type)*
- `npm run lint` *(fails: React Hook "useState" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_b_68a4b9537dc48324befc94213ea5b90b