### PR TITLE
chore: add expo-router babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,7 @@ module.exports = function(api) {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     },
   ],
+  require.resolve('expo-router/babel'),
   // This plugin MUST be listed last.
   'react-native-reanimated/plugin'
 ],


### PR DESCRIPTION
## Summary
- insert `expo-router/babel` plugin before `react-native-reanimated`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find module 'eslint')
- `npm start`


------
https://chatgpt.com/codex/tasks/task_b_68a4bd2133d4832486758a4dfbf0a01e