### PR TITLE
Disable React Native new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
## Summary
- disable React Native new architecture in `app.json`

## Testing
- `npx expo prebuild`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React Hooks must be called conditionally, no eslint config)*

------
https://chatgpt.com/codex/tasks/task_b_68a4c2d319b083249858a2c197b13668