### PR TITLE
feat: open custom timelines modal from goals header

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -1080,6 +1080,7 @@ if (!startDate || !endDate) {
           const timeline = customTimelines.find(t => t.id === selectedTimelineId);
           return timeline?.title;
         })()}
+        onEditPress={() => setIsCustomTimelinesModalVisible(true)}
       />
       
       <>


### PR DESCRIPTION
## Summary
- expose edit icon in Goals header that opens the custom timelines manager

## Testing
- `npm run lint` *(fails: 17 errors, 127 warnings)*


------
https://chatgpt.com/codex/tasks/task_b_68c03e2caecc83249625ac4755a33872