### PR TITLE
Validate date strings and handle invalid dates

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -72,7 +72,9 @@ export default function Goals() { // Ensure this is the default export
   const safeParseDate = (d: string, context: string): Date | null => {
     try {
       if (!isValidDateString(d)) throw new Error('Invalid date');
-      return parseLocalDate(d);
+      const parsed = parseLocalDate(d);
+      if (isNaN(parsed.getTime())) throw new Error('Invalid date');
+      return parsed;
     } catch (err) {
       console.warn(`Invalid date in ${context}:`, d, err);
       return null;

--- a/components/cycles/CycleSetupModal.tsx
+++ b/components/cycles/CycleSetupModal.tsx
@@ -438,12 +438,17 @@ console.log('Active cycle after global sync:', activeCycle);
                 onPress={() => setShowStartCalendar(true)}
               >
                 <Text style={styles.dateButtonText}>
-                  {parseLocalDate(customStartDate).toLocaleDateString('en-US', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
+                  {(() => {
+                    const parsed = parseLocalDate(customStartDate);
+                    return isNaN(parsed.getTime())
+                      ? 'Invalid date'
+                      : parsed.toLocaleDateString('en-US', {
+                          weekday: 'long',
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric'
+                        });
+                  })()}
                 </Text>
               </TouchableOpacity>
             </View>
@@ -455,12 +460,17 @@ console.log('Active cycle after global sync:', activeCycle);
                 onPress={() => setShowEndCalendar(true)}
               >
                 <Text style={styles.dateButtonText}>
-                  {parseLocalDate(customEndDate).toLocaleDateString('en-US', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
+                  {(() => {
+                    const parsed = parseLocalDate(customEndDate);
+                    return isNaN(parsed.getTime())
+                      ? 'Invalid date'
+                      : parsed.toLocaleDateString('en-US', {
+                          weekday: 'long',
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric'
+                        });
+                  })()}
                 </Text>
               </TouchableOpacity>
             </View>
@@ -470,6 +480,9 @@ console.log('Active cycle after global sync:', activeCycle);
                 Duration: {(() => {
                   const start = parseLocalDate(customStartDate);
                   const end = parseLocalDate(customEndDate);
+                  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+                    return 'Invalid date range';
+                  }
                   const days = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
                   const weeks = Math.ceil(days / 7);
                   return `${days} days (${weeks} weeks)`;
@@ -620,7 +633,11 @@ console.log('Active cycle after global sync:', activeCycle);
                     // Auto-adjust end date if it's before the new start date
                     const newStartDate = parseLocalDate(day.dateString);
                     const currentEndDate = parseLocalDate(customEndDate);
-                    if (currentEndDate <= newStartDate) {
+                    if (
+                      !isNaN(newStartDate.getTime()) &&
+                      !isNaN(currentEndDate.getTime()) &&
+                      currentEndDate <= newStartDate
+                    ) {
                       const newEndDate = new Date(newStartDate);
                       newEndDate.setDate(newEndDate.getDate() + 84); // 12 weeks default
                       setCustomEndDate(formatLocalDate(newEndDate));
@@ -656,12 +673,20 @@ console.log('Active cycle after global sync:', activeCycle);
                     // Validate that end date is after start date
                     const selectedEndDate = parseLocalDate(day.dateString);
                     const currentStartDate = parseLocalDate(customStartDate);
-                    
+
+                    if (
+                      isNaN(selectedEndDate.getTime()) ||
+                      isNaN(currentStartDate.getTime())
+                    ) {
+                      Alert.alert('Invalid Date', 'Please select valid dates');
+                      return;
+                    }
+
                     if (selectedEndDate <= currentStartDate) {
                       Alert.alert('Invalid Date', 'End date must be after start date');
                       return;
                     }
-                    
+
                     setCustomEndDate(day.dateString);
                     setShowEndCalendar(false);
                   }}

--- a/components/goals/CreateGoalModal.tsx
+++ b/components/goals/CreateGoalModal.tsx
@@ -252,10 +252,16 @@ const { data: roleKRData, error: roleKRError } = await supabase
     const dates: string[] = [];
     const start = parseLocalDate(startDate);
     const end = parseLocalDate(endDate);
-    
+
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      console.warn('Invalid dates provided to getDatesForRecurrence:', { startDate, endDate });
+      return dates;
+    }
+
     // Calculate how many days per week based on recurrence type
-    const daysPerWeek = recurrenceType === 'daily' ? 7 : parseInt(recurrenceType.replace('days', '').replace('day', ''));
-    
+    const daysPerWeek =
+      recurrenceType === 'daily' ? 7 : parseInt(recurrenceType.replace('days', '').replace('day', ''));
+
     // Generate dates for the week
     const current = new Date(start);
     let dayCount = 0;

--- a/components/goals/GoalProgressCard.tsx
+++ b/components/goals/GoalProgressCard.tsx
@@ -86,6 +86,9 @@ export function GoalProgressCard({
     if (goal.goal_type === 'custom') {
       const startDate = parseLocalDate(goal.start_date);
       const endDate = parseLocalDate(goal.end_date);
+      if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+        return 'Invalid date range';
+      }
       const totalDays = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
       const totalWeeks = Math.ceil(totalDays / 7);
       return `${totalWeeks}-Week Custom Goal`;
@@ -98,12 +101,17 @@ export function GoalProgressCard({
   const generateWeekDays = (startDateString: string) => {
     const days = [];
     const start = parseLocalDate(startDateString); // Use parseLocalDate to avoid timezone shifts
-    
+
+    if (isNaN(start.getTime())) {
+      console.warn('Invalid start date provided to generateWeekDays:', startDateString);
+      return days;
+    }
+
     console.log('=== GENERATE WEEK DAYS DEBUG ===');
     console.log('Input start date string:', startDateString);
     console.log('Parsed start date:', start.toISOString());
     console.log('Start day of week:', start.getDay()); // 0=Sunday, 1=Monday, etc.
-    
+
     // Generate 7 consecutive days starting from the provided start date
     for (let i = 0; i < 7; i++) {
       const day = new Date(start);
@@ -115,10 +123,10 @@ export function GoalProgressCard({
         dayOfWeek: day.getDay(),
       });
     }
-    
+
     console.log('Generated days:', days);
     console.log('=== END GENERATE WEEK DAYS DEBUG ===');
-    
+
     return days;
   };
 
@@ -269,6 +277,9 @@ export function GoalProgressCard({
                   const startDate = parseLocalDate(goal.start_date);
                   const endDate = parseLocalDate(goal.end_date);
                   const now = new Date();
+                  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+                    return 'Invalid dates';
+                  }
                   const totalDays = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
                   const daysRemaining = Math.max(0, Math.ceil((endDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
                   return `${daysRemaining}/${totalDays} days`;
@@ -285,6 +296,9 @@ export function GoalProgressCard({
                       const startDate = parseLocalDate(goal.start_date);
                       const endDate = parseLocalDate(goal.end_date);
                       const now = new Date();
+                      if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+                        return 0;
+                      }
                       const totalDays = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
                       const daysPassed = Math.max(0, Math.ceil((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)));
                       return Math.min(100, (daysPassed / totalDays) * 100);

--- a/lib/__tests__/dateUtils.test.js
+++ b/lib/__tests__/dateUtils.test.js
@@ -1,0 +1,21 @@
+require('ts-node/register');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseLocalDate } = require('../dateUtils');
+
+test('parseLocalDate returns valid Date for ISO string', () => {
+  const date = parseLocalDate('2024-08-31');
+  assert.equal(date.getFullYear(), 2024);
+  assert.equal(date.getMonth(), 7); // August is month 7 (0-indexed)
+  assert.equal(date.getDate(), 31);
+});
+
+test('parseLocalDate returns invalid Date for empty string', () => {
+  const date = parseLocalDate('');
+  assert.ok(isNaN(date.getTime()));
+});
+
+test('parseLocalDate returns invalid Date for non-string input', () => {
+  const date = parseLocalDate(null);
+  assert.ok(isNaN(date.getTime()));
+});

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -26,7 +26,15 @@ export function formatLocalDate(date: Date): string {
  * Parses a YYYY-MM-DD string as a local date (no timezone conversion)
  */
 export function parseLocalDate(dateString: string): Date {
-  const [year, month, day] = dateString.split('-').map(Number);
+  if (typeof dateString !== 'string' || dateString.trim() === '') {
+    return new Date(NaN);
+  }
+
+  const parts = dateString.split('-');
+  if (parts.length !== 3) {
+    return new Date(NaN);
+  }
+  const [year, month, day] = parts.map(Number);
   return new Date(year, month - 1, day);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint-config-expo": "~9.2.0",
         "metro": "^0.82.0",
         "shx": "^0.4.0",
+        "ts-node": "^10.9.2",
         "typescript": "~5.8.3"
       }
     },
@@ -1543,6 +1544,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -3571,6 +3596,34 @@
         "@supabase/storage-js": "^2.10.4"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -4347,6 +4400,19 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5507,6 +5573,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
@@ -5792,6 +5865,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -9202,6 +9285,13 @@
         "react-native": "*",
         "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -12665,6 +12755,57 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-object-utils": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
@@ -13034,6 +13175,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
@@ -13405,6 +13553,16 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "expo start",
     "build:web": "npm run clean:web && cross-env EXPO_NO_TELEMETRY=1 npx expo export -p web --output-dir build",
     "clean:web": "shx rm -rf build",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node --test lib/__tests__/dateUtils.test.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -60,6 +61,7 @@
     "eslint-config-expo": "~9.2.0",
     "metro": "^0.82.0",
     "shx": "^0.4.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- validate and sanitize date strings before parsing
- skip or warn on invalid dates when rendering timelines, cycles, and goals
- add unit tests for parseLocalDate valid/invalid cases

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name; react/display-name)*

------
https://chatgpt.com/codex/tasks/task_b_68c07ab420548324ba2e02ea8191c6aa