### PR TITLE
Handle ISO date strings with time components

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -72,7 +72,8 @@ export default function Goals() { // Ensure this is the default export
   const safeParseDate = (d: string, context: string): Date | null => {
     try {
       if (!isValidDateString(d)) throw new Error('Invalid date');
-      const parsed = parseLocalDate(d);
+      // Support ISO strings that include time components by stripping them
+      const parsed = parseLocalDate(d.split('T')[0]);
       if (isNaN(parsed.getTime())) throw new Error('Invalid date');
       return parsed;
     } catch (err) {

--- a/lib/__tests__/dateUtils.test.js
+++ b/lib/__tests__/dateUtils.test.js
@@ -10,6 +10,20 @@ test('parseLocalDate returns valid Date for ISO string', () => {
   assert.equal(date.getDate(), 31);
 });
 
+test('parseLocalDate handles ISO string with time component (Z)', () => {
+  const date = parseLocalDate('2025-06-01T00:00:00Z');
+  assert.equal(date.getFullYear(), 2025);
+  assert.equal(date.getMonth(), 5); // June
+  assert.equal(date.getDate(), 1);
+});
+
+test('parseLocalDate handles ISO string with timezone offset', () => {
+  const date = parseLocalDate('2025-06-01T12:34:56+02:00');
+  assert.equal(date.getFullYear(), 2025);
+  assert.equal(date.getMonth(), 5); // June
+  assert.equal(date.getDate(), 1);
+});
+
 test('parseLocalDate returns invalid Date for empty string', () => {
   const date = parseLocalDate('');
   assert.ok(isNaN(date.getTime()));

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -29,12 +29,20 @@ export function parseLocalDate(dateString: string): Date {
   if (typeof dateString !== 'string' || dateString.trim() === '') {
     return new Date(NaN);
   }
+  // If an ISO string with time component is provided (e.g. 2025-06-01T00:00:00Z),
+  // strip everything after the date portion before parsing.
+  const datePart = dateString.split('T')[0];
 
-  const parts = dateString.split('-');
+  const parts = datePart.split('-');
   if (parts.length !== 3) {
     return new Date(NaN);
   }
+
   const [year, month, day] = parts.map(Number);
+  if ([year, month, day].some((n) => Number.isNaN(n))) {
+    return new Date(NaN);
+  }
+
   return new Date(year, month - 1, day);
 }
 


### PR DESCRIPTION
## Summary
- Strip time components when parsing ISO dates to avoid invalid dates
- Support ISO timestamps in Goals screen's safe date parsing
- Add unit tests covering ISO strings with time and timezone offsets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c080012cd883248b9c722096a37c88