### PR TITLE
feat: add weekly goal navigator

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '@/components/Header';
+import { WeeklyGoalNavigator } from '@/components/goals/WeeklyGoalNavigator';
 
 export default function Goals() {
 
@@ -13,7 +14,7 @@ export default function Goals() {
       />
       
       <View style={styles.content}>
-        <Text style={styles.placeholderText}>Goal Bank feature coming soon!</Text>
+        <WeeklyGoalNavigator />
       </View>
     </SafeAreaView>
   );
@@ -26,13 +27,6 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
     padding: 16,
-  },
-  placeholderText: {
-    fontSize: 16,
-    color: '#6b7280',
-    textAlign: 'center',
   },
 });

--- a/components/goals/WeeklyGoalNavigator.tsx
+++ b/components/goals/WeeklyGoalNavigator.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+// Helper to get Monday as the start of the week
+function startOfWeek(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  // Adjust when day is Sunday (0) to get previous Monday
+  const diff = (day === 0 ? -6 : 1) - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+// Helper to add days to a date
+function addDays(date: Date, amount: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + amount);
+  return d;
+}
+
+export function WeeklyGoalNavigator() {
+  const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
+
+  const days = useMemo(() => {
+    return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  }, [weekStart]);
+
+  const goToPreviousWeek = () => setWeekStart(addDays(weekStart, -7));
+  const goToNextWeek = () => setWeekStart(addDays(weekStart, 7));
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.navigation}>
+        <TouchableOpacity onPress={goToPreviousWeek} style={styles.navButton}>
+          <Text style={styles.navButtonText}>{'<'}</Text>
+        </TouchableOpacity>
+        <Text style={styles.weekLabel}>
+          {weekStart.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}
+        </Text>
+        <TouchableOpacity onPress={goToNextWeek} style={styles.navButton}>
+          <Text style={styles.navButtonText}>{'>'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.daysRow}>
+        {days.map((day) => (
+          <View key={day.toISOString()} style={styles.dayItem}>
+            <Text style={styles.dayLabel}>
+              {day.toLocaleDateString('en-US', { weekday: 'short' })}
+            </Text>
+            <Text style={styles.dayNumber}>{day.getDate()}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 16,
+    backgroundColor: '#ffffff',
+  },
+  navigation: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  navButton: {
+    padding: 8,
+  },
+  navButtonText: {
+    fontSize: 18,
+    color: '#0078d4',
+  },
+  weekLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  daysRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+  },
+  dayItem: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  dayLabel: {
+    fontSize: 12,
+    color: '#6b7280',
+    marginBottom: 4,
+  },
+  dayNumber: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+});
+


### PR DESCRIPTION
## Summary
- add weekly goal navigator for navigating days within a week
- show weekly navigator on goals tab

## Testing
- `npm run lint` *(fails: React Hook useState is called conditionally, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68c0b3245b7483248b9845effd7cb278