### PR TITLE
feat(goal-navigation): display dynamic week range

### DIFF
--- a/components/goals/WeeklyGoalNavigator.tsx
+++ b/components/goals/WeeklyGoalNavigator.tsx
@@ -21,6 +21,11 @@ function addDays(date: Date, amount: number): Date {
 
 export function WeeklyGoalNavigator() {
   const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
+  const weekEnd = useMemo(() => addDays(weekStart, 6), [weekStart]);
+  const weekLabel = useMemo(() => {
+    const options = { month: 'long', day: 'numeric' } as const;
+    return `${weekStart.toLocaleDateString('en-US', options)} - ${weekEnd.toLocaleDateString('en-US', options)}`;
+  }, [weekStart, weekEnd]);
 
   const days = useMemo(() => {
     return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -35,9 +40,7 @@ export function WeeklyGoalNavigator() {
         <TouchableOpacity onPress={goToPreviousWeek} style={styles.navButton}>
           <Text style={styles.navButtonText}>{'<'}</Text>
         </TouchableOpacity>
-        <Text style={styles.weekLabel}>
-          {weekStart.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}
-        </Text>
+        <Text style={styles.weekLabel}>{weekLabel}</Text>
         <TouchableOpacity onPress={goToNextWeek} style={styles.navButton}>
           <Text style={styles.navButtonText}>{'>'}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- compute week end date from week start
- show dynamic start-end range in week label

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: No ESLint config found. Configuring automatically.)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_b_68c0bba3a97c832481059e7bf9f3737a