### PR TITLE
refactor: track cycle weeks by start/end

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -68,6 +68,11 @@ export default function Goals() { // Ensure this is the default export
  const { width } = useWindowDimensions();
   const twoUp = Platform.OS === 'web' && width >= 768;
 
+  // Use current week index as a fallback before selectedWeekIndex is initialized
+  const weekIndex = selectedWeekIndex === -1
+    ? (selectedTimelineId === 'twelve-week' ? getCurrentWeekIndex() : 0)
+    : selectedWeekIndex;
+
   const isValidDateString = (d?: string) => typeof d === 'string' && d !== 'null' && !isNaN(Date.parse(d));
   const safeParseDate = (d: string, context: string): Date | null => {
     try {
@@ -161,9 +166,9 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
 
       // Use cycle weeks for 12-week timeline; use custom weeks otherwise
       const wk = selectedTimelineId === 'twelve-week'
-        ? getWeekData(selectedWeekIndex)
+        ? getWeekData(weekIndex)
         : (() => {
-            const w = customTimelineWeeks[selectedWeekIndex];
+            const w = customTimelineWeeks[weekIndex];
             if (!w) return null;
             return {
               weekNumber: w.week_number,
@@ -337,7 +342,7 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
   };
 
   const formatWeekHeader = () => {
-    const weekData = getWeekData(selectedWeekIndex);
+    const weekData = getWeekData(weekIndex);
     if (!weekData) return 'Week 1';
 
     const startDate = safeParseDate(weekData.startDate, 'formatWeekHeader start');
@@ -796,17 +801,17 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
                 <Text style={styles.weekNumber}>
                   Week {(() => {
                     if (selectedTimelineId === 'twelve-week') {
-                      return getWeekData(selectedWeekIndex)?.weekNumber || 1;
+                      return getWeekData(weekIndex)?.weekNumber || 1;
                     } else {
-                      return customTimelineWeeks[selectedWeekIndex]?.week_number || 1;
+                      return customTimelineWeeks[weekIndex]?.week_number || 1;
                     }
                   })()}
                 </Text>
                 <Text style={styles.weekDates}>
                   {(() => {
                     const weekData = selectedTimelineId === 'twelve-week'
-                      ? getWeekData(selectedWeekIndex)
-                      : customTimelineWeeks[selectedWeekIndex];
+                      ? getWeekData(weekIndex)
+                      : customTimelineWeeks[weekIndex];
                     if (!weekData) return '';
                     const startDate = safeParseDate(weekData.startDate, 'week display start');
                     const endDate = safeParseDate(weekData.endDate, 'week display end');
@@ -863,8 +868,8 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
             {twelveWeekGoals.map(goal => {
               const progress = goalProgress[goal.id];
               const weekData = selectedTimelineId === 'twelve-week' 
-                ? getWeekData(selectedWeekIndex)
-                : customTimelineWeeks[selectedWeekIndex];
+                ? getWeekData(weekIndex)
+                : customTimelineWeeks[weekIndex];
               const goalActions = weekGoalActions[goal.id] || [];
               if (!progress) return null;
 
@@ -903,7 +908,7 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
     const timeline = customTimelines.find(t => t.id === selectedTimelineId);
     if (!timeline) return null;
 
-    const weekData = customTimelineWeeks[selectedWeekIndex];
+    const weekData = customTimelineWeeks[weekIndex];
 
     return (
       <ScrollView style={styles.content}>
@@ -1007,11 +1012,11 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
 
               <View style={styles.weekDisplay}>
                 <Text style={styles.weekNumber}>
-                  Week {customTimelineWeeks[selectedWeekIndex]?.week_number || 1}
+                  Week {customTimelineWeeks[weekIndex]?.week_number || 1}
                 </Text>
                 <Text style={styles.weekDates}>
                   {(() => {
-                    const weekData = customTimelineWeeks[selectedWeekIndex];
+                    const weekData = customTimelineWeeks[weekIndex];
                     if (!weekData) return '';
                     const startDate = safeParseDate(weekData.startDate, 'custom timeline week start');
                     const endDate = safeParseDate(weekData.endDate, 'custom timeline week end');
@@ -1096,14 +1101,14 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
   }
 };
 
-  const currentWeek = getWeekData(selectedWeekIndex);
-  
+  const currentWeek = getWeekData(weekIndex);
+
   // Don't render week-dependent content until we have a valid week selection
-  if (selectedWeekIndex === -1 || !currentWeek) {
+  if (!currentWeek) {
     return (
       <SafeAreaView style={styles.container}>
-        <Header 
-          title="Goal Bank" 
+        <Header
+          title="Goal Bank"
           authenticScore={authenticScore}
           daysRemaining={daysLeftData?.days_left}
           cycleProgressPercentage={daysLeftData?.pct_elapsed}
@@ -1296,8 +1301,8 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
                     overallTarget: 0,
                     overallProgress: 0,
                   }}
-                  week={selectedTimelineId === 'twelve-week' ? getWeekData(selectedWeekIndex) : customTimelineWeeks[selectedWeekIndex]}
-                  selectedWeekNumber={selectedTimelineId === 'twelve-week' ? getWeekData(selectedWeekIndex)?.weekNumber : customTimelineWeeks[selectedWeekIndex]?.week_number}
+                  week={selectedTimelineId === 'twelve-week' ? getWeekData(weekIndex) : customTimelineWeeks[weekIndex]}
+                  selectedWeekNumber={selectedTimelineId === 'twelve-week' ? getWeekData(weekIndex)?.weekNumber : customTimelineWeeks[weekIndex]?.week_number}
                   weekActions={weekGoalActions[selectedGoalForModal.id] || []}
                   loadingWeekActions={loadingWeekActions}
                   onAddAction={() => {

--- a/components/goals/ActionEffortModal.tsx
+++ b/components/goals/ActionEffortModal.tsx
@@ -41,8 +41,8 @@ interface TwelveWeekGoal {
 
 interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
   user_cycle_id: string;
 }
 

--- a/components/goals/CreateGoalModal.tsx
+++ b/components/goals/CreateGoalModal.tsx
@@ -37,8 +37,8 @@ interface Domain {
 
 interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
 }
 
 interface CreateGoalModalProps {

--- a/hooks/useGoalProgress.ts
+++ b/hooks/useGoalProgress.ts
@@ -537,11 +537,11 @@ if (week1.week_start !== expectedWeek1Start.start_date) {
   .select('*')
   .in('task_id', taskIds);
 
-      if (isValidISODate(weekData.start_date)) {
-        weeklyQuery = weeklyQuery.gte('measured_on', weekData.start_date);
+      if (isValidISODate(weekData.week_start)) {
+        weeklyQuery = weeklyQuery.gte('measured_on', weekData.week_start);
       }
-      if (isValidISODate(weekData.end_date)) {
-        weeklyQuery = weeklyQuery.lte('measured_on', weekData.end_date);
+      if (isValidISODate(weekData.week_end)) {
+        weeklyQuery = weeklyQuery.lte('measured_on', weekData.week_end);
       }
 
       const { data: taskLogsData, error: taskLogsError } = await weeklyQuery;
@@ -621,19 +621,19 @@ if (week1.week_start !== expectedWeek1Start.start_date) {
           let weeklyQuery = supabase
             .from('0008-ap-tasks')
             .select('*')
-            .in('parent_task_id', taskIds)
-            .eq('status', 'completed');
+          .in('parent_task_id', taskIds)
+          .eq('status', 'completed');
 
-          if (isValidISODate(currentWeekData.start_date)) {
-            weeklyQuery = weeklyQuery.gte('due_date', currentWeekData.start_date);
-          }
-          if (isValidISODate(currentWeekData.end_date)) {
-            weeklyQuery = weeklyQuery.lte('due_date', currentWeekData.end_date);
-          }
+        if (isValidISODate(currentWeekData.week_start)) {
+          weeklyQuery = weeklyQuery.gte('due_date', currentWeekData.week_start);
+        }
+        if (isValidISODate(currentWeekData.week_end)) {
+          weeklyQuery = weeklyQuery.lte('due_date', currentWeekData.week_end);
+        }
 
-          const { data: weeklyOccurrences } = await weeklyQuery;
+        const { data: weeklyOccurrences } = await weeklyQuery;
 
-          weeklyActual = weeklyOccurrences?.length || 0;
+        weeklyActual = weeklyOccurrences?.length || 0;
         }
 
         // Fetch completed occurrences for entire cycle

--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -59,8 +59,8 @@ export interface UserCycle {
 
 export interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
   user_cycle_id: string;
 }
 
@@ -146,8 +146,8 @@ export async function fetchGoalActionsForWeek(
         w => w.week_number === weekNumber || (w as any).weekNumber === weekNumber
       );
 
-    const weekStartDate = (week as any)?.start_date ?? (week as any)?.startDate;
-    const weekEndDate = (week as any)?.end_date ?? (week as any)?.endDate;
+    const weekStartDate = (week as any)?.week_start ?? (week as any)?.startDate;
+    const weekEndDate = (week as any)?.week_end ?? (week as any)?.endDate;
     if (!weekStartDate || !weekEndDate) return {};
 
     const { data: goalJoins } = await supabase
@@ -337,8 +337,8 @@ export function useGoals(options: UseGoalsOptions = {}) {
       // Map database columns to expected interface
       const mappedWeeks = (dbWeeks ?? []).map(week => ({
         week_number: week.week_number,
-        start_date: week.start_date,
-        end_date: week.end_date,
+        week_start: week.week_start,
+        week_end: week.week_end,
         user_cycle_id: week.user_cycle_id,
       }));
       
@@ -531,8 +531,8 @@ export function useGoals(options: UseGoalsOptions = {}) {
             .select('*')
             .in('parent_task_id', taskIds)
             .eq('status', 'completed')
-            .gte('due_date', currentWeekData.start_date)
-            .lte('due_date', currentWeekData.end_date);
+            .gte('due_date', currentWeekData.week_start)
+            .lte('due_date', currentWeekData.week_end);
 
           weeklyActual = weeklyOccurrences?.length || 0;
         }
@@ -590,9 +590,10 @@ export function useGoals(options: UseGoalsOptions = {}) {
     
     const now = new Date();
     const currentDateString = formatLocalDate(now);
-    
-    const currentWeekData = cycleWeeks.find(week => 
-      currentDateString >= week.start_date && currentDateString <= week.end_date
+
+    const currentWeekData = cycleWeeks.find(
+      week =>
+        currentDateString >= week.week_start && currentDateString <= week.week_end
     );
     
     return currentWeekData?.week_number || 1;


### PR DESCRIPTION
## Summary
- switch CycleWeek to `week_start`/`week_end`
- use week boundaries when fetching cycle weeks and determining current week
- update goal progress and goal modals to new week fields
- ensure Goal Bank falls back to current week when none selected

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE in dateUtils.test.js)*
- `npm run lint` *(fails: 17 errors, 128 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c2cbe216388324ba3f2d8887fe3271