### PR TITLE
refactor: track cycle weeks by start/end

### DIFF
--- a/components/goals/ActionEffortModal.tsx
+++ b/components/goals/ActionEffortModal.tsx
@@ -41,8 +41,8 @@ interface TwelveWeekGoal {
 
 interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
   user_cycle_id: string;
 }
 

--- a/components/goals/CreateGoalModal.tsx
+++ b/components/goals/CreateGoalModal.tsx
@@ -37,8 +37,8 @@ interface Domain {
 
 interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
 }
 
 interface CreateGoalModalProps {

--- a/hooks/useGoalProgress.ts
+++ b/hooks/useGoalProgress.ts
@@ -537,11 +537,11 @@ if (week1.week_start !== expectedWeek1Start.start_date) {
   .select('*')
   .in('task_id', taskIds);
 
-      if (isValidISODate(weekData.start_date)) {
-        weeklyQuery = weeklyQuery.gte('measured_on', weekData.start_date);
+      if (isValidISODate(weekData.week_start)) {
+        weeklyQuery = weeklyQuery.gte('measured_on', weekData.week_start);
       }
-      if (isValidISODate(weekData.end_date)) {
-        weeklyQuery = weeklyQuery.lte('measured_on', weekData.end_date);
+      if (isValidISODate(weekData.week_end)) {
+        weeklyQuery = weeklyQuery.lte('measured_on', weekData.week_end);
       }
 
       const { data: taskLogsData, error: taskLogsError } = await weeklyQuery;
@@ -621,19 +621,19 @@ if (week1.week_start !== expectedWeek1Start.start_date) {
           let weeklyQuery = supabase
             .from('0008-ap-tasks')
             .select('*')
-            .in('parent_task_id', taskIds)
-            .eq('status', 'completed');
+          .in('parent_task_id', taskIds)
+          .eq('status', 'completed');
 
-          if (isValidISODate(currentWeekData.start_date)) {
-            weeklyQuery = weeklyQuery.gte('due_date', currentWeekData.start_date);
-          }
-          if (isValidISODate(currentWeekData.end_date)) {
-            weeklyQuery = weeklyQuery.lte('due_date', currentWeekData.end_date);
-          }
+        if (isValidISODate(currentWeekData.week_start)) {
+          weeklyQuery = weeklyQuery.gte('due_date', currentWeekData.week_start);
+        }
+        if (isValidISODate(currentWeekData.week_end)) {
+          weeklyQuery = weeklyQuery.lte('due_date', currentWeekData.week_end);
+        }
 
-          const { data: weeklyOccurrences } = await weeklyQuery;
+        const { data: weeklyOccurrences } = await weeklyQuery;
 
-          weeklyActual = weeklyOccurrences?.length || 0;
+        weeklyActual = weeklyOccurrences?.length || 0;
         }
 
         // Fetch completed occurrences for entire cycle

--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -59,8 +59,8 @@ export interface UserCycle {
 
 export interface CycleWeek {
   week_number: number;
-  start_date: string;
-  end_date: string;
+  week_start: string;
+  week_end: string;
   user_cycle_id: string;
 }
 
@@ -146,8 +146,8 @@ export async function fetchGoalActionsForWeek(
         w => w.week_number === weekNumber || (w as any).weekNumber === weekNumber
       );
 
-    const weekStartDate = (week as any)?.start_date ?? (week as any)?.startDate;
-    const weekEndDate = (week as any)?.end_date ?? (week as any)?.endDate;
+    const weekStartDate = (week as any)?.week_start ?? (week as any)?.startDate;
+    const weekEndDate = (week as any)?.week_end ?? (week as any)?.endDate;
     if (!weekStartDate || !weekEndDate) return {};
 
     const { data: goalJoins } = await supabase
@@ -337,8 +337,8 @@ export function useGoals(options: UseGoalsOptions = {}) {
       // Map database columns to expected interface
       const mappedWeeks = (dbWeeks ?? []).map(week => ({
         week_number: week.week_number,
-        start_date: week.start_date,
-        end_date: week.end_date,
+        week_start: week.week_start,
+        week_end: week.week_end,
         user_cycle_id: week.user_cycle_id,
       }));
       
@@ -531,8 +531,8 @@ export function useGoals(options: UseGoalsOptions = {}) {
             .select('*')
             .in('parent_task_id', taskIds)
             .eq('status', 'completed')
-            .gte('due_date', currentWeekData.start_date)
-            .lte('due_date', currentWeekData.end_date);
+            .gte('due_date', currentWeekData.week_start)
+            .lte('due_date', currentWeekData.week_end);
 
           weeklyActual = weeklyOccurrences?.length || 0;
         }
@@ -590,9 +590,10 @@ export function useGoals(options: UseGoalsOptions = {}) {
     
     const now = new Date();
     const currentDateString = formatLocalDate(now);
-    
-    const currentWeekData = cycleWeeks.find(week => 
-      currentDateString >= week.start_date && currentDateString <= week.end_date
+
+    const currentWeekData = cycleWeeks.find(
+      week =>
+        currentDateString >= week.week_start && currentDateString <= week.week_end
     );
     
     return currentWeekData?.week_number || 1;
@@ -604,14 +605,13 @@ export function useGoals(options: UseGoalsOptions = {}) {
   };
 
   const getWeekData = (weekIndex: number): WeekData | null => {
-    const weekNumber = weekIndex + 1;
-    const weekData = cycleWeeks.find(w => w.week_number === weekNumber);
-    if (!weekData) return null;
+    const week = cycleWeeks[weekIndex];
+    if (!week) return null;
 
     return {
-      weekNumber,
-      startDate: weekData.week_start,
-      endDate: weekData.week_end,
+      weekNumber: week.week_number,
+      startDate: week.week_start,
+      endDate: week.week_end,
     };
   };
 


### PR DESCRIPTION
## Summary
- switch CycleWeek to `week_start`/`week_end`
- use week boundaries when fetching cycle weeks and determining current week
- update goal progress and goal modals to new week fields
- ensure Goal Bank and timeline navigation fall back to current week when none selected
- fix week navigator to display dates for selected week

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 127 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c2cbe216388324ba3f2d8887fe3271