### PR TITLE
Reset week selection when cycle or timeline changes

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -129,13 +129,11 @@ export default function Goals() { // Ensure this is the default export
   }, []);
 
   // Initialize selected week to current week (for both cycle and custom timelines)
-useEffect(() => {
-  if (!initializedWeekRef.current) {
+  useEffect(() => {
     if (selectedTimelineId === 'twelve-week' && cycleWeeks.length > 0) {
-      const currentWeekIndex = getCurrentWeekIndex();
-setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.length - 1);
+      setSelectedWeekIndex(getCurrentWeekIndex());
       initializedWeekRef.current = true;
-    } else if (selectedTimelineId && customTimelineWeeks.length > 0) {
+    } else if (!initializedWeekRef.current && selectedTimelineId && customTimelineWeeks.length > 0) {
       const now = new Date();
       const currentDateString = formatLocalDate(now);
       const currentWeekIndex = customTimelineWeeks.findIndex(
@@ -144,8 +142,7 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
       setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : 0);
       initializedWeekRef.current = true;
     }
-  }
-}, [selectedTimelineId, cycleWeeks, customTimelineWeeks, getCurrentWeekIndex]);
+  }, [selectedTimelineId, cycleWeeks, customTimelineWeeks, getCurrentWeekIndex]);
 
   // Fetch week-specific actions when week or goals change
   useEffect(() => {
@@ -520,12 +517,15 @@ setSelectedWeekIndex(currentWeekIndex >= 0 ? currentWeekIndex : cycleWeeks.lengt
   };
 
   const handleTimelineSelect = (timelineId: string) => {
-    setSelectedTimelineId(timelineId);
-    if (timelineId !== 'twelve-week') {
-      // Load custom timeline data
-      loadCustomTimelineData(timelineId);
-    }
-  };
+      setSelectedTimelineId(timelineId);
+      initializedWeekRef.current = false;
+      if (timelineId === 'twelve-week') {
+        setSelectedWeekIndex(getCurrentWeekIndex());
+      } else {
+        // Load custom timeline data
+        loadCustomTimelineData(timelineId);
+      }
+    };
 
   const loadCustomTimelineData = async (timelineId: string) => {
     try {

--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -600,8 +600,23 @@ export function useGoals(options: UseGoalsOptions = {}) {
   };
 
   const getCurrentWeekIndex = (): number => {
-    const weekIndex = Math.max(0, getCurrentWeekNumber() - 1);
-    return weekIndex;
+    if (cycleWeeks.length === 0) return -1;
+
+    const now = new Date();
+    const currentDateString = formatLocalDate(now);
+
+    const index = cycleWeeks.findIndex(
+      w => currentDateString >= w.week_start && currentDateString <= w.week_end
+    );
+
+    if (index !== -1) return index;
+
+    const firstWeek = cycleWeeks[0];
+    const lastWeek = cycleWeeks[cycleWeeks.length - 1];
+    if (currentDateString < firstWeek.week_start) return 0;
+    if (currentDateString > lastWeek.week_end) return cycleWeeks.length - 1;
+
+    return -1;
   };
 
   const getWeekData = (weekIndex: number): WeekData | null => {


### PR DESCRIPTION
## Summary
- Reset selected week to current cycle week whenever cycle data or timeline selection changes
- Update timeline selector to refresh week index when switching back to 12-week view
- Derive current week index from available cycle weeks and current date

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name, React Hook useEffect has a missing dependency, and more)*

------
https://chatgpt.com/codex/tasks/task_b_68c309a462d883248b69f9bcfb218b32