### PR TITLE
Fetch cycle weeks start and end dates

### DIFF
--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -323,7 +323,7 @@ export function useGoals(options: UseGoalsOptions = {}) {
       
       const { data: dbWeeks, error } = await supabase
         .from('v_user_cycle_weeks')
-        .select('week_number, week_start, week_end, user_cycle_id')
+        .select('week_number, start_date:week_start, end_date:week_end, user_cycle_id')
         .eq('user_cycle_id', userCycleId)
         .order('week_number', { ascending: true })
         .returns<CycleWeek[]>();


### PR DESCRIPTION
## Summary
- query cycle weeks with start and end dates
- map aliased start/end fields to CycleWeek objects

## Testing
- `npx ts-node -e "const { generateCycleWeeks } = require('./lib/dateUtils'); const weeks = generateCycleWeeks('2024-01-01'); const mapped = weeks.map((w: any) => ({ week_number: w.week_number, week_start: w.start_date, week_end: w.end_date, user_cycle_id: 'cycle1'})); console.log(mapped.length); console.log(mapped[0]); console.log(mapped[11]);"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c3128bf4508324bb72c6205ce275f9