### PR TITLE
chore: remove obsolete week handler

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -319,17 +319,6 @@ export default function Goals() { // Ensure this is the default export
     }
   };
 
-  const handleWeekChange = (direction: 'prev' | 'next') => {
-    // Only allow navigation if we have a valid week selection
-    if (selectedWeekIndex === -1) return;
-    
-    const newIndex = direction === 'prev' 
-      ? Math.max(0, selectedWeekIndex - 1)
-      : Math.min(11, selectedWeekIndex + 1);
-    
-    setSelectedWeekIndex(newIndex);
-  };
-
   const goPrevWeek = () => {
     console.log('goPrevWeek called, current index:', selectedWeekIndex);
     setSelectedWeekIndex(prev => {


### PR DESCRIPTION
## Summary
- remove unused handleWeekChange helper from goals tab
- ensure week navigation relies on goPrevWeek/goNextWeek with dynamic bounds

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c31352e2948324b573beb215304588