### PR TITLE
Handle invalid base dates in weekly goal navigator

### DIFF
--- a/components/goals/WeeklyGoalNavigator.tsx
+++ b/components/goals/WeeklyGoalNavigator.tsx
@@ -31,7 +31,14 @@ export function WeeklyGoalNavigator() {
         const res = await fetch('/api/current-week');
         if (!res.ok) throw new Error('Failed to fetch current week');
         const data = await res.json();
-        setWeekStart(new Date(data.start));
+        let baseDate = new Date(data.start);
+        if (isNaN(baseDate.getTime())) {
+          console.warn(
+            `Invalid date received for current week: ${data.start}. Using current date instead.`
+          );
+          baseDate = new Date();
+        }
+        setWeekStart(baseDate);
         setError(null);
       } catch (err) {
         setError('Unable to load current week.');


### PR DESCRIPTION
## Summary
- Validate API-provided dates in WeeklyGoalNavigator and default to current date when invalid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors, 58 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c32c25bce8832488faaf179f845ea1