### PR TITLE
Filter custom goals by source in useGoals hook

### DIFF
--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -417,12 +417,16 @@ export function useGoals(options: UseGoalsOptions = {}) {
       }
 
       // Fetch custom goals (independent of cycles)
-     const { data: customData, error: customError } = await supabase
-  .from('v_unified_goals')
-  .select('*')
-  .eq('user_id', user.id)
-  .eq('status', 'active')
-  .order('created_at', { ascending: false });
+      const {
+        data: customData,
+        error: customError
+      } = await supabase
+        .from('v_unified_goals')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('status', 'active')
+        .eq('source', 'custom')
+        .order('created_at', { ascending: false });
 
       if (customError) throw customError;
 


### PR DESCRIPTION
## Summary
- restrict the v_unified_goals query in useGoals to pull only custom goals
- ensure downstream goal id aggregation continues to operate on the filtered set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c97e78db548324b40c05b91c5a873d