### PR TITLE
Fix custom goal count query

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -267,7 +267,7 @@ export default function Goals() {
               .from('0008-ap-goals-custom')
               .select('id')
               .eq('user_id', user.id)
-              .eq('timeline_id', timeline.id)
+              .eq('custom_timeline_id', timeline.id)
               .eq('status', 'active');
 
             if (!error) {


### PR DESCRIPTION
## Summary
- update the custom goal count query to match the custom timeline identifier when counting goals

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_b_68c983f92be0832490c3f9812cb7fa3f