### PR TITLE
Normalize goal type handling across goal hooks

### DIFF
--- a/components/goals/GoalProgressCard.tsx
+++ b/components/goals/GoalProgressCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Platform } from 'react-native';
 import { Target, Calendar, Plus, TrendingUp, Check, CreditCard as Edit } from 'lucide-react-native';
-import { GoalProgress } from '@/hooks/useGoalProgress';
+import { GoalProgress, type UnifiedGoal as Goal } from '@/hooks/useGoalProgress';
 import { parseLocalDate, formatLocalDate } from '@/lib/dateUtils';
 
 interface WeekData {

--- a/hooks/useGoals.ts
+++ b/hooks/useGoals.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { getSupabaseClient } from '../lib/supabase';
 import { Alert } from 'react-native';
 import { generateCycleWeeks, formatLocalDate, parseLocalDate } from '../lib/dateUtils';
+import { normalizeGoalType } from '../lib/goalTypes';
 
 export interface TwelveWeekGoal {
   id: string;
@@ -224,7 +225,7 @@ export async function fetchGoalActionsForWeek(
 
       const taskWithLogs: TaskWithLogs = {
         ...task,
-        goal_type: goalJoin.goal_type === 'twelve_wk_goal' ? '12week' : 'custom',
+        goal_type: normalizeGoalType(goalJoin.goal_type, 'custom'),
         logs: taskLogs,
         weeklyActual: cappedWeeklyActual,
         weeklyTarget,

--- a/lib/goalTypes.ts
+++ b/lib/goalTypes.ts
@@ -1,0 +1,34 @@
+export type GoalType = '12week' | 'custom';
+export type DatabaseGoalType = 'twelve_wk_goal' | 'custom_goal';
+
+export const CANONICAL_TO_DB_GOAL_TYPE: Record<GoalType, DatabaseGoalType> = {
+  '12week': 'twelve_wk_goal',
+  custom: 'custom_goal',
+} as const;
+
+export const DB_TO_CANONICAL_GOAL_TYPE: Record<DatabaseGoalType, GoalType> = {
+  twelve_wk_goal: '12week',
+  custom_goal: 'custom',
+} as const;
+
+export const normalizeGoalType = (
+  value: string | null | undefined,
+  fallback: GoalType = 'custom'
+): GoalType => {
+  switch (value) {
+    case '12week':
+    case 'custom':
+      return value;
+    case 'twelve_wk_goal':
+      return '12week';
+    case 'custom_goal':
+      return 'custom';
+    default:
+      return fallback;
+  }
+};
+
+export const goalJoinColumnForType = (
+  goalType: GoalType
+): 'twelve_wk_goal_id' | 'custom_goal_id' =>
+  goalType === 'custom' ? 'custom_goal_id' : 'twelve_wk_goal_id';


### PR DESCRIPTION
## Summary
- introduce canonical goal type helpers and apply them in goal progress state
- update goal progress and goal list hooks to map database goal_type values
- align GoalProgressCard typing with the unified goal shape

## Testing
- npm test -- hooks/__tests__/fetchGoalActionsForWeek.test.js

------
https://chatgpt.com/codex/tasks/task_b_68c9955d024c8324a28d6e958f9e9c30