### PR TITLE
Initialize goalsData before use

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -280,7 +280,7 @@ export default function Goals() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-        const { data, error: queryError } = await supabase
+      let goalsData: any[] = [];
 
       if (timeline.source === 'global') {
         // Fetch only 12-week goals for global timelines


### PR DESCRIPTION
## Summary
- initialize the goalsData array before branching on timeline source
- remove the unused supabase query placeholder left between the user lookup and timeline fetch logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c9d5fc040883248567c5cd93c4a12d