### PR TITLE
Include primary goal in task goal joins

### DIFF
--- a/components/tasks/TaskEventForm.tsx
+++ b/components/tasks/TaskEventForm.tsx
@@ -377,7 +377,11 @@ const toDateString = (date: Date) => {
             const roleJoins = formData.selectedRoleIds.map(role_id => ({ parent_id: taskId, parent_type: 'task', role_id, user_id: user.id }));
             const domainJoins = formData.selectedDomainIds.map(domain_id => ({ parent_id: taskId, parent_type: 'task', domain_id, user_id: user.id }));
             const krJoins = formData.selectedKeyRelationshipIds.map(key_relationship_id => ({ parent_id: taskId, parent_type: 'task', key_relationship_id, user_id: user.id }));
-            const goalJoins = formData.selectedGoalIds.map(goal_id => ({ parent_id: taskId, parent_type: 'task', goal_id, user_id: user.id }));
+            const goalIds = new Set<string>(formData.selectedGoalIds);
+            if (formData.selectedGoalId) {
+                goalIds.add(formData.selectedGoalId);
+            }
+            const goalJoins = Array.from(goalIds).map(goal_id => ({ parent_id: taskId, parent_type: 'task', goal_id, user_id: user.id }));
 
             // Only add a new note if there's content in the notes field
             if (formData.notes && formData.notes.trim()) {


### PR DESCRIPTION
## Summary
- include both the single selected goal and any multi-selected goals when building task/event goal joins
- de-duplicate goal ids before inserting into 0008-ap-universal-goals-join to avoid duplicate records

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_b_68c9daaa69348324abd129446b8810af