### PR TITLE
Refresh custom timeline weeks view for renamed columns

### DIFF
--- a/supabase/migrations/20250821153000_refresh_custom_timeline_weeks.sql
+++ b/supabase/migrations/20250821153000_refresh_custom_timeline_weeks.sql
@@ -1,0 +1,12 @@
+-- Refresh custom timeline weeks view to use standardized start/end column names
+DROP VIEW IF EXISTS v_custom_timeline_weeks;
+
+CREATE VIEW v_custom_timeline_weeks AS
+SELECT
+  ROW_NUMBER() OVER (PARTITION BY uc.id ORDER BY week_start)::int AS week_number,
+  week_start::date AS start_date,
+  LEAST((week_start + interval '6 days')::date, uc.end_date) AS end_date,
+  uc.id AS timeline_id,
+  'custom'::text AS source
+FROM "0008-ap-user-cycles" uc
+CROSS JOIN generate_series(uc.start_date, uc.end_date, interval '1 week') AS week_start;


### PR DESCRIPTION
## Summary
- drop and recreate `v_custom_timeline_weeks` so it uses the new `start_date`/`end_date` columns from `0008-ap-user-cycles`
- preserve week numbering, timeline id, and source values while capping each week at the cycle end date

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_b_68c9daac01ac8324a8ae174d7015ef0b