### PR TITLE
Update timeline week views to use standardized dates

### DIFF
--- a/supabase/migrations/20250821153000_refresh_custom_timeline_weeks.sql
+++ b/supabase/migrations/20250821153000_refresh_custom_timeline_weeks.sql
@@ -1,4 +1,5 @@
 -- Refresh custom timeline weeks view to use standardized start/end column names
+DROP VIEW IF EXISTS v_unified_timeline_weeks;
 DROP VIEW IF EXISTS v_custom_timeline_weeks;
 
 CREATE VIEW v_custom_timeline_weeks AS
@@ -10,3 +11,23 @@ SELECT
   'custom'::text AS source
 FROM "0008-ap-user-cycles" uc
 CROSS JOIN generate_series(uc.start_date, uc.end_date, interval '1 week') AS week_start;
+
+CREATE VIEW v_unified_timeline_weeks AS
+SELECT
+  week_number,
+  start_date,
+  end_date,
+  timeline_id,
+  source
+FROM v_custom_timeline_weeks
+
+UNION ALL
+
+SELECT
+  ROW_NUMBER() OVER (PARTITION BY gc.id ORDER BY week_start)::int AS week_number,
+  week_start::date AS start_date,
+  LEAST((week_start + interval '6 days')::date, gc.end_date) AS end_date,
+  gc.id AS timeline_id,
+  'global'::text AS source
+FROM "0008-ap-global-cycles" gc
+CROSS JOIN generate_series(gc.start_date, gc.end_date, interval '1 week') AS week_start;


### PR DESCRIPTION
## Summary
- drop and recreate `v_unified_timeline_weeks` alongside the custom timeline weeks view
- ensure the unified view unions custom timelines with global cycle weeks using the standardized `start_date`/`end_date`

## Testing
- npx supabase start *(fails: Docker daemon not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9e5a5caa08324a507d47abb53482b