### PR TITLE
Ensure custom timeline weeks view drop and grant

### DIFF
--- a/supabase/migrations/20250916120000_fix_custom_timeline_weeks_view.sql
+++ b/supabase/migrations/20250916120000_fix_custom_timeline_weeks_view.sql
@@ -1,3 +1,5 @@
+DROP VIEW IF EXISTS v_custom_timeline_weeks;
+
 -- Ensure v_custom_timeline_weeks exposes the expected week boundaries
 CREATE OR REPLACE VIEW v_custom_timeline_weeks AS
 SELECT
@@ -29,3 +31,5 @@ CROSS JOIN LATERAL (
   SELECT (ct.start_date + ((gs.week_number - 1) * INTERVAL '7 days'))::date AS base_date
 ) AS derived
 WHERE ct.status = 'active';
+
+GRANT SELECT ON v_custom_timeline_weeks TO authenticated;


### PR DESCRIPTION
## Summary
- drop v_custom_timeline_weeks before recreating it to avoid stale view definitions
- reapply the SELECT grant so authenticated users retain access after the drop

## Testing
- npx supabase db push *(fails: project not linked in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9eeb529fc83248348ec7286f501db