### PR TITLE
Fix custom timeline week selection for goals tab

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -480,7 +480,7 @@ export default function Goals() {
         // Fetch custom timeline weeks
         const { data: weeksData, error: weeksError } = await supabase
           .from('v_custom_timeline_weeks')
-          .select('week_number, week_start, week_end')
+          .select('week_number, start_date, end_date')
           .eq('custom_timeline_id', timeline.id)
           .order('week_number', { ascending: true });
 
@@ -494,7 +494,13 @@ export default function Goals() {
 
         if (daysError && daysError.code !== 'PGRST116') throw daysError;
 
-        setTimelineWeeks((weeksData as TimelineWeek[]) || []);
+        const mappedWeeks: TimelineWeek[] = (weeksData || []).map((week: any) => ({
+          week_number: week.week_number,
+          start_date: week.start_date,
+          end_date: week.end_date,
+        }));
+
+        setTimelineWeeks(mappedWeeks);
         setTimelineDaysLeft(daysData);
       } else if (timeline.source === 'global') {
         // Fetch global timeline weeks


### PR DESCRIPTION
## Summary
- update the custom timeline weeks query to request start and end date columns
- map the returned rows into TimelineWeek objects before updating state

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_b_68ca3c5fc74883249909420305ca8777